### PR TITLE
feat(soft-delete): implement soft delete with 'isDeleted' column

### DIFF
--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   Patch,
   Param,
+  Delete,
 } from '@nestjs/common';
 import { BookService } from './book.service';
 import { CreateBookDto, PaginationDto, UpdateBookDto } from './dto';
@@ -32,5 +33,10 @@ export class BookController {
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.bookService.findBookById(id);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.bookService.deleteBookById(id);
   }
 }

--- a/src/modules/book/book.module.ts
+++ b/src/modules/book/book.module.ts
@@ -6,6 +6,7 @@ import { Book, BookSchema } from './entities/book.schema';
 import { Author, AuthorSchema, Genres, GenresSchema } from './entities';
 import {
   CreateBookService,
+  DeleteBookByIdService,
   FindAllBooksService,
   FindBookByIdService,
   updateBookService,
@@ -41,6 +42,7 @@ import {
     FindAllBooksService,
     updateBookService,
     FindBookByIdService,
+    DeleteBookByIdService,
   ],
   exports: [InsertGenresService, InsertAuthorservice],
 })

--- a/src/modules/book/book.service.ts
+++ b/src/modules/book/book.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import {
   CreateBookService,
+  DeleteBookByIdService,
   FindAllBooksService,
   FindBookByIdService,
   updateBookService,
@@ -15,6 +16,7 @@ export class BookService {
     private readonly findAllBooksService: FindAllBooksService,
     private readonly updateBookService: updateBookService,
     private readonly findBooksService: FindBookByIdService,
+    private readonly deleteBookService: DeleteBookByIdService,
   ) {}
 
   async createBook(createBookDto: CreateBookDto): Promise<Book> {
@@ -30,5 +32,9 @@ export class BookService {
   }
   async findBookById(id: string): Promise<Book> {
     return this.findBooksService.findById(id);
+  }
+
+  async deleteBookById(id: string): Promise<string> {
+    return await this.deleteBookService.deleteBookById(id);
   }
 }

--- a/src/modules/book/entities/book.schema.ts
+++ b/src/modules/book/entities/book.schema.ts
@@ -21,6 +21,9 @@ export class Book {
 
   @Prop({ type: [Types.ObjectId], ref: 'Genres' })
   genres: Types.ObjectId[];
+
+  @Prop({ default: false })
+  isDeleted: boolean;
 }
 
 export const BookSchema = SchemaFactory.createForClass(Book);

--- a/src/modules/book/services/book/delete-book.service.ts
+++ b/src/modules/book/services/book/delete-book.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Book } from '../../entities';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class DeleteBookByIdService {
+  constructor(
+    @InjectModel(Book.name) private readonly modelBook: Model<Book>,
+  ) {}
+
+  async deleteBookById(id: string): Promise<string> {
+    const book = this.modelBook.findByIdAndUpdate(
+      id,
+      { isDeleted: true },
+      { new: true },
+    );
+    if (!book) throw new NotFoundException(`Book with Id: ${id} not found`);
+
+    return `Book with Id: ${id} has been deleted`;
+  }
+}

--- a/src/modules/book/services/book/index.ts
+++ b/src/modules/book/services/book/index.ts
@@ -1,4 +1,5 @@
 export * from './create-book.service';
+export * from './delete-book.service';
 export * from './find-all-books.service';
 export * from './find-book-by-id.service';
 export * from './update-book.service';


### PR DESCRIPTION
This pull request introduces soft delete functionality for the Book entity by adding an isDeleted column. The new functionality allows books to be marked as deleted without removing them from the database, enabling better data integrity and the possibility of restoring deleted books in the future.

Changes Made:

Added an isDeleted boolean field to the Book schema.
Updated the delete service to use findByIdAndUpdate to set isDeleted to true instead of removing the document.
Ensured that soft-deleted books are not returned in the standard queries.